### PR TITLE
pin pytest

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,7 +48,8 @@ test:
     - click  # [not osx]
     - netcdf4  # [not osx]
     - responses
-    - pytest
+    # see https://docs.pytest.org/en/latest/changelog.html#removals
+    - pytest <5.1.0
     - pytest-xdist
     - mock  # [py27]
     - futures  # [py27]


### PR DESCRIPTION
pytest.config was removed in 5.1.0
see https://docs.pytest.org/en/latest/changelog.html#removals